### PR TITLE
fix: Not enough arguments to removeEventListener (Firefox 43.0)

### DIFF
--- a/chrome/content/overlay.js
+++ b/chrome/content/overlay.js
@@ -377,7 +377,7 @@ remotecontrol = {
 window.addEventListener(
     "load",
     function remoteControlOnload() {
-        window.removeEventListener(remoteControlOnload);
+        window.removeEventListener('load', remoteControlOnload);
         remotecontrol.onLoad();
     },
     false,


### PR DESCRIPTION
![enu3ae6](https://cloud.githubusercontent.com/assets/425208/12031860/7bbf2446-ae1a-11e5-81ea-0eeebff19e5c.png)
Hello @nneonneo Can you review this changes?