### PR TITLE
fix: start automatically with environment variable

### DIFF
--- a/chrome/content/overlay.js
+++ b/chrome/content/overlay.js
@@ -289,13 +289,16 @@ remotecontrol = {
     },
 
     maybeStartAutomatically: function () {
-        var start = Components.classes[
-                "@morch.com/remotecontrol/command-line-handler;1"
-            ]
+        var hasCommandLineStartFlag = Components.classes["@morch.com/remotecontrol/command-line-handler;1"]
             .getService()
             .wrappedJSObject
             .startRemoteControlOnce();
-        if (start) {
+
+        var startEnvironmentVariable = Components.classes["@mozilla.org/process/environment;1"]
+            .getService(Components.interfaces.nsIEnvironment)
+            .get('FIREFOX_START_REMOTE_CONTROL');
+
+        if (hasCommandLineStartFlag || startEnvironmentVariable == 1) {
             this.startControlSocket();
 
             // Adjust button.checked state


### PR DESCRIPTION
There is one feature in README
> But it is possible to start Remote Control automatically when Firefox starts by setting the environment FIREFOX_START_REMOTE_CONTROL=1. If that environment variable is set and the icon is present on the toolbar, it will start when Firefox starts. The requirement for the icon to be present is to avoid this extension being used for malicious purposes without the user knowing.

But is is not implemented (deleted by someone)
I try to fix it and test: `export FIREFOX_START_REMOTE_CONTROL=1` and start firefox. All works fine