### PR TITLE
Add custom commands and fix remote-call initialization

### DIFF
--- a/chrome/content/overlay.js
+++ b/chrome/content/overlay.js
@@ -289,13 +289,16 @@ remotecontrol = {
     },
 
     maybeStartAutomatically: function () {
-        var start = Components.classes[
-                "@morch.com/remotecontrol/command-line-handler;1"
-            ]
+        var hasCommandLineStartFlag = Components.classes["@morch.com/remotecontrol/command-line-handler;1"]
             .getService()
             .wrappedJSObject
             .startRemoteControlOnce();
-        if (start) {
+
+        var startEnvironmentVariable = Components.classes["@mozilla.org/process/environment;1"]
+            .getService(Components.interfaces.nsIEnvironment)
+            .get('FIREFOX_START_REMOTE_CONTROL');
+
+        if (hasCommandLineStartFlag || startEnvironmentVariable == 1) {
             this.startControlSocket();
 
             // Adjust button.checked state


### PR DESCRIPTION
Simple script for custom commands
```sh
#!/usr/bin/env bash

ffc(){
  for command in "$@"
  do
      echo "$command" | nc -q 1 127.0.0.1 32000 ;
  done
}

# open two tabs
ffc newtab "//:use_active_tab" "window.location='http://google.ua'"      
ffc newtab "//:use_active_tab" "window.location='http://github.com'"

# find google tab and change location
ffc "//:use_tab /google\./i" "window.location='http://gist.github.com'"

ffc "//:get_tab_list"

```